### PR TITLE
chore: bootstrap suite-standards adoption (2026-05-05a)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,69 @@
+<!--
+This file is synced from cogworks/shared/.github/ISSUE_TEMPLATE/bug.md.
+Edits to the canonical version live there. Per-cog overrides go via .cogworks-sync-skip.
+-->
+
+---
+name: Bug report
+about: Something is misbehaving in-game
+title: '[bug] '
+labels: ['bug', 'needs-triage']
+---
+
+## Steps to reproduce
+
+<!--
+Numbered list. Be specific enough that an agent (or another player) could re-walk it without asking.
+
+Example:
+1. Open the bank in a city.
+2. Click the "Deposit Reagents" drawer button.
+3. Observe the chat output.
+-->
+
+1.
+2.
+3.
+
+## Expected behavior
+
+<!-- What you thought would happen. -->
+
+## Actual behavior
+
+<!-- What actually happened. Include error messages verbatim if any. -->
+
+## Environment
+
+- Cog + version: <!-- e.g. flipqueue v0.12.0-alpha17. Run `/<cog> version` if available. -->
+- WoW build: <!-- retail / classic / cataclysm; build number if you have it -->
+- Cogworks-1.0 version: <!-- shown by `/<cog> version` or in the About page; "embedded in cog" is fine if you don't know -->
+- Other addons that might interact: <!-- TSM, Auctionator, Syndicator, Journalator, Bagnon, ElvUI, etc. -->
+
+## Severity (filer's best guess; triage may adjust)
+
+- [ ] **Critical** — blocks login, corrupts saved variables, or causes a Lua error on every UI open
+- [ ] **High** — functional regression with a workaround
+- [ ] **Medium** — annoyance or confusing behavior
+- [ ] **Low** — cosmetic / polish
+
+## Diagnostics
+
+<!--
+Run `/<cog> debug` (e.g. `/tally debug`, `/fq debug`) → click "Copy diagnostics" →
+paste the output here. Or open the cog's About page and click the same button.
+
+This bundles version + settings + state + recent debug log into one block.
+Without it, triage usually round-trips back to you for the same info.
+-->
+
+```
+<paste Copy diagnostics output here>
+```
+
+## Additional context
+
+<!--
+Optional. Screenshots, BugSack output, related ticket links.
+For Discord-mirrored reports: paste the relevant scribe-bridged thread link here.
+-->

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,55 @@
+<!--
+This file is synced from cogworks/shared/.github/ISSUE_TEMPLATE/task.md.
+Edits to the canonical version live there. Per-cog overrides go via .cogworks-sync-skip.
+-->
+
+---
+name: Task / feature
+about: Implementation work, refactor, chore
+title: ''
+labels: ['needs-triage']
+---
+
+## Goal
+
+<!-- One sentence. What outcome does this ticket produce? -->
+
+## Acceptance criteria
+
+<!--
+Bulleted, testable. An agent should be able to look at this list and decide "am I done?".
+
+Example for a chore:
+- `.pkgmeta` `Libs/Cogworks-1.0` external is pinned to `v0.13.2` (was `v0.13.1`)
+- `release.yml` `verify-package.yml` ref is pinned to `@v0.13.2` (was `@main`)
+- Local `bash scripts/pre-tag-check.sh v0.12.0-alpha18` passes F1–F7
+- PR description states which in-game flow was exercised post-bump
+
+Example for a feature:
+- `/fq config import-window 30` slash command sets the import window in seconds
+- Setting persists across `/reload`
+- Default value is unchanged (no migration needed)
+- About page surfaces the current value
+-->
+
+-
+
+## Out of scope
+
+<!--
+Optional but recommended. Prevents scope creep mid-implementation. State adjacent things that COULD be done but explicitly aren't part of this ticket.
+
+Example:
+- Updating other cogs' `.pkgmeta` pins — those get their own per-cog tickets.
+- Refactoring the pre-cluster dedup pass — that's TLY-N.
+-->
+
+-
+
+## References
+
+<!--
+Optional. Linked tickets, runbook references, PR drafts.
+- Master ticket: COG-N
+- Runbook: cogworks/runbooks/library-bump-propagation.md
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,44 @@
+<!--
+This file is synced from cogworks/shared/.github/pull_request_template.md.
+Edits to the canonical version live there. Per-cog overrides go via .cogworks-sync-skip.
+-->
+
+## What
+
+<!-- One sentence: what this PR does. -->
+
+## Why
+
+Closes <COG>-N <!-- or Refs <COG>-N if not closing -->
+
+<!-- One sentence on the underlying motivation if not obvious from the linked issue. -->
+
+## What was tested
+
+<!--
+Required. State the manual verification path you actually walked. "N/A — packaging only" or "N/A — docs only" is acceptable when literally true.
+
+Examples that work for review:
+- "/reload, opened the bank, confirmed deposit-tasks button still fires; manually deposited reagents, no change in behavior."
+- "Ran `bash scripts/pre-tag-check.sh v0.14.0-alpha1` — passed F1–F7."
+- "Imported a 50k-row TSM CSV; /tally diag showed `compressMs` < 300ms post-fix."
+- "N/A — runbook edit only."
+-->
+
+## Self-review checklist
+
+- [ ] Issue linked above (`Closes <ID>` or `Refs <ID>`)
+- [ ] Manual exercise described above (or "N/A — <reason>")
+- [ ] CI green on this branch (`verify-package` + any other workflow checks)
+- [ ] No leftover debug prints / TODOs without a follow-up ticket
+- [ ] RELEASES.md updated under `## Unreleased` (or "N/A — eng-only / docs-only / etc.")
+- [ ] CHANGELOG.md updated under `## [Unreleased]` (or "N/A — same reasons")
+- [ ] If this PR bumps Cogworks-1.0 in `.pkgmeta` or the workflow ref: bumped both to the same tag, in this PR alone (no other changes bundled)
+
+## Out-of-scope follow-ups
+
+<!--
+Optional. Anything you noticed but deliberately deferred. Each item should already have a ticket OR a one-line note that it needs one.
+- "Refactor the pre-cluster dedup pass — TLY-N to file"
+- "Tooltip text alignment is off in classic; same root as #142, leaving for that PR"
+-->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,19 @@ Tally is the personal-finance layer of the Cogworks suite — Personal Capital /
 - **Vendored libs.** All libraries except Cogworks-1.0 live directly in `Libs/`. Cogworks-1.0 is pulled at package time via a pinned-tag git external in `.pkgmeta`.
 - **Additive Cogworks API use.** When using Cogworks, only rely on APIs that exist at or below the pinned tag. Bump the tag in `.pkgmeta` to pick up newer features — never rely on unpinned main.
 
+## Standards acknowledgments
+
+Each session, check the top entry of each source against the codes below. If newer, prefix the first response with `Standards updated:` plus a one-line summary per new entry, then update the code below as part of the session's commit.
+
+| Source | Last acknowledged |
+|---|---|
+| [comms conventions](https://github.com/gezmodean-wow/cogworks/blob/main/runbooks/comms-conventions.md) | 2026-05-05a |
+| [branch & release flow](https://github.com/gezmodean-wow/cogworks/blob/main/runbooks/branch-and-release-flow.md) | 2026-05-05a |
+| [doc conventions](https://github.com/gezmodean-wow/cogworks/blob/main/runbooks/doc-conventions.md) | 2026-05-05a |
+| [technical standards](https://github.com/gezmodean-wow/cogworks/blob/main/runbooks/technical-standards.md) | 2026-05-05a |
+| [shared/ file pool](https://github.com/gezmodean-wow/cogworks/blob/main/shared/VERSION) | 2026-05-05a — `bash scripts/sync-standards.sh check` |
+| [standards-sync (this mechanism)](https://github.com/gezmodean-wow/cogworks/blob/main/runbooks/standards-sync.md) | 2026-05-05a |
+
 ## SavedVariables
 
 - `TallyDB` — account-wide

--- a/scripts/pre-tag-check.sh
+++ b/scripts/pre-tag-check.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# pre-tag-check.sh — mechanical pre-tag gate for chronoforge cogs.
+#
+# Synced from cogworks/shared/scripts/pre-tag-check.sh; edits to the canonical
+# version live there. Add the file to .cogworks-sync-skip to opt out per cog.
+#
+# Usage:
+#   bash scripts/pre-tag-check.sh <tag>
+# Examples:
+#   bash scripts/pre-tag-check.sh v0.14.0-alpha1
+#   bash scripts/pre-tag-check.sh v0.14.0
+#
+# Exit 0 = mechanical checks passed (F8 still requires human confirmation).
+# Exit 1 = one or more hard failures.
+# Exit 2 = usage error.
+#
+# See cogworks/runbooks/branch-and-release-flow.md for what F1–F8 mean.
+
+set -euo pipefail
+
+TAG="${1:-}"
+if [[ -z "$TAG" ]]; then
+  echo "usage: $0 <tag>" >&2
+  echo "       e.g. $0 v0.14.0-alpha1" >&2
+  exit 2
+fi
+
+errors=0
+warnings=0
+
+fail() { echo "FAIL: $*" >&2; errors=$((errors+1)); }
+warn() { echo "WARN: $*" >&2; warnings=$((warnings+1)); }
+ok()   { echo "  ok: $*"; }
+note() { echo "note: $*"; }
+
+echo "Pre-tag check for tag: $TAG"
+echo
+
+# ── F1: working tree clean on main/master ──────────────────────────────────
+echo "[F1] working tree clean on main/master"
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+if [[ "$branch" != "main" && "$branch" != "master" ]]; then
+  fail "not on main/master (current branch: $branch)"
+else
+  ok "on $branch"
+fi
+if [[ -n "$(git status --porcelain)" ]]; then
+  fail "working tree dirty (uncommitted changes present)"
+else
+  ok "working tree clean"
+fi
+
+# ── F2: CI green on the tag's commit ───────────────────────────────────────
+echo "[F2] CI green on HEAD"
+if command -v gh >/dev/null 2>&1; then
+  status=$(gh run list --branch "$branch" --limit 1 --json conclusion --jq '.[0].conclusion' 2>/dev/null || echo "unknown")
+  case "$status" in
+    success) ok "latest run on $branch concluded: success" ;;
+    "")      warn "no recent runs found on $branch (gh returned empty)" ;;
+    unknown) warn "could not query gh for run status (auth or network?)" ;;
+    *)       fail "latest run on $branch concluded: $status" ;;
+  esac
+else
+  warn "gh not installed; cannot verify CI status — confirm manually before tagging"
+fi
+
+# ── F3: .pkgmeta Cogworks pin (advisory) ───────────────────────────────────
+echo "[F3] .pkgmeta Cogworks-1.0 pin"
+if [[ -f .pkgmeta ]]; then
+  pin=$(awk '
+    /Cogworks-1\.0:/ { in_block=1; next }
+    in_block && /tag:/ { gsub(/^[[:space:]]+tag:[[:space:]]*/, ""); print; exit }
+    in_block && /^[^[:space:]]/ { in_block=0 }
+  ' .pkgmeta || echo "")
+  if [[ -n "$pin" ]]; then
+    ok "Cogworks-1.0 pinned to $pin"
+    note "F3 is advisory — confirm $pin matches what was tested in F8"
+  else
+    warn "could not parse Cogworks-1.0 tag from .pkgmeta"
+  fi
+else
+  note "no .pkgmeta in this repo (skipping F3)"
+fi
+
+# ── F4: RELEASES.md has section for tag ────────────────────────────────────
+echo "[F4] RELEASES.md has section for $TAG"
+if [[ -f RELEASES.md ]]; then
+  if grep -qE "^## \[?${TAG//./\\.}(\]| |$)" RELEASES.md; then
+    ok "RELEASES.md has $TAG section"
+  else
+    fail "RELEASES.md missing section for $TAG (heading must match '## $TAG' or '## [$TAG]')"
+  fi
+else
+  note "no RELEASES.md in this repo (skipping F4 — verify this is intentional, e.g. cogworks)"
+fi
+
+# ── F5: CHANGELOG.md has entry for tag ─────────────────────────────────────
+echo "[F5] CHANGELOG.md has entry for $TAG"
+if [[ -f CHANGELOG.md ]]; then
+  if grep -qE "^## \[?${TAG//./\\.}(\]| |$)" CHANGELOG.md; then
+    ok "CHANGELOG.md has $TAG section"
+  else
+    fail "CHANGELOG.md missing section for $TAG"
+  fi
+else
+  fail "CHANGELOG.md not found — every cog needs an engineering changelog"
+fi
+
+# ── F6: tag name uses literal "alpha"/"beta" (not -aN/-bN) ─────────────────
+echo "[F6] tag naming convention"
+if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-z0-9.]+)?$ ]]; then
+  if [[ "$TAG" =~ -[ab][0-9]+$ ]]; then
+    fail "tag '$TAG' uses '-aN'/'-bN' shorthand; BigWigsMods packager needs literal 'alpha'/'beta'"
+  else
+    ok "tag format looks well-formed"
+  fi
+else
+  warn "tag '$TAG' does not match vX.Y.Z[-suffix] pattern (verify intentional)"
+fi
+
+# ── F7: closed-issue refs since previous tag are in CHANGELOG (advisory) ───
+echo "[F7] closed-issue refs since previous tag covered in CHANGELOG"
+prev_tag=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+if [[ -n "$prev_tag" ]] && [[ -f CHANGELOG.md ]]; then
+  commit_msgs=$(git log --format=%s%n%b "$prev_tag..HEAD" 2>/dev/null || echo "")
+  refs=$(echo "$commit_msgs" | grep -oE '([A-Z]+-[0-9]+|#[0-9]+)' | sort -u || true)
+  missing=()
+  if [[ -n "$refs" ]]; then
+    while IFS= read -r ref; do
+      [[ -z "$ref" ]] && continue
+      if ! grep -qF "$ref" CHANGELOG.md; then
+        missing+=("$ref")
+      fi
+    done <<< "$refs"
+  fi
+  if (( ${#missing[@]} == 0 )); then
+    ok "all referenced issues since $prev_tag appear in CHANGELOG.md"
+  else
+    warn "issue refs in commits since $prev_tag but missing from CHANGELOG.md: ${missing[*]}"
+  fi
+else
+  note "no previous tag found or CHANGELOG missing (skipping F7)"
+fi
+
+# ── F8: human-only reminder ────────────────────────────────────────────────
+echo "[F8] in-game smoke test (human-only)"
+note "F8 is not checked by this script — the agent must explicitly confirm with the user"
+
+# ── Summary ────────────────────────────────────────────────────────────────
+echo
+echo "─────────────────────────────────"
+if (( errors > 0 )); then
+  echo "Pre-tag check: $errors error(s), $warnings warning(s) — FAIL"
+  exit 1
+fi
+if (( warnings > 0 )); then
+  echo "Pre-tag check: $warnings warning(s) — review before proceeding"
+fi
+echo "Mechanical checks passed. F8 (in-game smoke test) still requires human confirmation."
+exit 0

--- a/scripts/sync-standards.sh
+++ b/scripts/sync-standards.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# sync-standards.sh — agent-driven cogworks shared/ file sync.
+#
+# Synced from cogworks/shared/scripts/sync-standards.sh; edits to the canonical
+# version live there. Add this path to .cogworks-sync-skip to opt out per cog.
+#
+# This script handles ONLY the file-sync source (cogworks/shared/). Convention
+# sources (runbook acknowledgments, scribe PLAYER_FACING_CONVENTIONS) are
+# agent-applied behaviorally — see the "Standards acknowledgments" section in
+# this cog's CLAUDE.md.
+#
+# Usage:
+#   bash scripts/sync-standards.sh check    # report whether cog is current
+#   bash scripts/sync-standards.sh diff     # preview changes without applying
+#   bash scripts/sync-standards.sh apply    # fetch and apply latest standards
+#
+# Exit codes:
+#   0 — up to date / apply succeeded
+#   1 — outdated (check) / apply failed / unreachable source
+#   2 — usage error
+#
+# Source: https://raw.githubusercontent.com/gezmodean-wow/cogworks/main/shared/
+# Override file: .cogworks-sync-skip (one path / glob per line; # for comments)
+#
+# Acknowledgment is recorded in CLAUDE.md's "Standards acknowledgments" block,
+# not in this script. After a successful apply, update the `shared/` row's
+# "Last acknowledged" code to the new VERSION.
+
+set -euo pipefail
+
+COGWORKS_REPO="${COGWORKS_REPO:-gezmodean-wow/cogworks}"
+COGWORKS_REF="${COGWORKS_REF:-main}"
+SHARED_BASE="https://raw.githubusercontent.com/$COGWORKS_REPO/$COGWORKS_REF/shared"
+
+CMD="${1:-check}"
+
+fetch() {
+  local url="$1" dest="$2"
+  curl -fsSL --max-time 15 "$url" -o "$dest" 2>/dev/null
+}
+
+fetch_text() {
+  curl -fsSL --max-time 15 "$1" 2>/dev/null
+}
+
+get_remote_version() {
+  fetch_text "$SHARED_BASE/VERSION" || true
+}
+
+get_manifest() {
+  # cogworks/shared/MANIFEST is a hand-maintained list of paths under shared/,
+  # one per line, comments allowed. Adding a new sync target requires updating
+  # MANIFEST in cogworks. See cogworks/runbooks/standards-sync.md.
+  fetch_text "$SHARED_BASE/MANIFEST" || true
+}
+
+get_local_ack() {
+  # Pull the cog's currently-acknowledged shared/ version from CLAUDE.md.
+  # Format expected (single line in the Standards acknowledgments table):
+  #   | shared/ file pool | <code> |
+  # We grep that row and extract the second pipe-delimited field.
+  if [[ ! -f CLAUDE.md ]]; then
+    echo ""
+    return
+  fi
+  awk -F'|' '
+    /Standards acknowledgments/ { in_block=1; next }
+    in_block && /shared\// {
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", $3)
+      print $3
+      exit
+    }
+    in_block && /^##[[:space:]]/ { in_block=0 }
+  ' CLAUDE.md
+}
+
+is_skipped() {
+  local path="$1"
+  [[ -f .cogworks-sync-skip ]] || return 1
+  while IFS= read -r line; do
+    line="${line%%#*}"
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    [[ -z "$line" ]] && continue
+    # Glob match against full path
+    # shellcheck disable=SC2053
+    if [[ "$path" == $line ]]; then
+      return 0
+    fi
+  done < .cogworks-sync-skip
+  return 1
+}
+
+cmd_check() {
+  local remote local_ack
+  remote=$(get_remote_version)
+  if [[ -z "$remote" ]]; then
+    echo "ERROR: could not fetch $SHARED_BASE/VERSION (network or cogworks unreachable)" >&2
+    return 1
+  fi
+  local_ack=$(get_local_ack)
+
+  if [[ -z "$local_ack" ]]; then
+    echo "Standards not yet acknowledged in CLAUDE.md."
+    echo "Cogworks shared/ current: $remote"
+    echo "Bootstrap: run 'apply', then add the Standards acknowledgments block to CLAUDE.md."
+    return 1
+  fi
+
+  if [[ "$local_ack" == "$remote" ]]; then
+    echo "Up to date: shared/ at $local_ack"
+    return 0
+  fi
+
+  echo "Outdated:"
+  echo "  cog acknowledged: $local_ack"
+  echo "  cogworks current: $remote"
+  echo "Next: run 'diff' to preview, then 'apply' to update."
+  return 1
+}
+
+cmd_diff() {
+  local manifest tmpdir changed=0
+  manifest=$(get_manifest)
+  if [[ -z "$manifest" ]]; then
+    echo "ERROR: could not fetch MANIFEST" >&2
+    return 1
+  fi
+
+  tmpdir=$(mktemp -d)
+  trap 'rm -rf "$tmpdir"' RETURN
+
+  echo "Proposed changes from $SHARED_BASE:"
+  echo
+  while IFS= read -r path; do
+    path="${path%%#*}"
+    path="${path#"${path%%[![:space:]]*}"}"
+    path="${path%"${path##*[![:space:]]}"}"
+    [[ -z "$path" ]] && continue
+
+    if is_skipped "$path"; then
+      echo "  SKIP $path  (.cogworks-sync-skip)"
+      continue
+    fi
+
+    local tmpfile="$tmpdir/$(echo "$path" | tr '/' '_')"
+    if ! fetch "$SHARED_BASE/$path" "$tmpfile"; then
+      echo "  WARN $path  (could not fetch)"
+      continue
+    fi
+
+    if [[ ! -f "$path" ]]; then
+      echo "  NEW  $path"
+      changed=$((changed+1))
+    elif ! cmp -s "$path" "$tmpfile"; then
+      echo "  MOD  $path"
+      changed=$((changed+1))
+    else
+      echo "  ok   $path"
+    fi
+  done <<< "$manifest"
+
+  echo
+  if (( changed == 0 )); then
+    echo "No changes."
+    return 0
+  fi
+  echo "$changed file(s) would change."
+}
+
+cmd_apply() {
+  local manifest applied=0 skipped=0 failed=0
+  manifest=$(get_manifest)
+  if [[ -z "$manifest" ]]; then
+    echo "ERROR: could not fetch MANIFEST" >&2
+    return 1
+  fi
+
+  while IFS= read -r path; do
+    path="${path%%#*}"
+    path="${path#"${path%%[![:space:]]*}"}"
+    path="${path%"${path##*[![:space:]]}"}"
+    [[ -z "$path" ]] && continue
+
+    if is_skipped "$path"; then
+      skipped=$((skipped+1))
+      continue
+    fi
+
+    mkdir -p "$(dirname "$path")"
+    if fetch "$SHARED_BASE/$path" "$path"; then
+      applied=$((applied+1))
+    else
+      echo "FAIL: could not fetch $path" >&2
+      failed=$((failed+1))
+    fi
+  done <<< "$manifest"
+
+  if (( failed > 0 )); then
+    echo "Apply incomplete: $applied applied, $skipped skipped, $failed failed" >&2
+    return 1
+  fi
+
+  local remote
+  remote=$(get_remote_version)
+  echo "Applied $applied file(s); skipped $skipped (per .cogworks-sync-skip)."
+  echo "Cogworks shared/ version: $remote"
+  echo
+  echo "Next steps:"
+  echo "  1. Update CLAUDE.md Standards acknowledgments → shared/ row to $remote"
+  echo "  2. Review the diff: git status && git diff"
+  echo "  3. Open as chore PR: chore/sync-standards-$remote"
+  echo "  4. CI must pass before merge."
+  return 0
+}
+
+case "$CMD" in
+  check) cmd_check ;;
+  diff)  cmd_diff ;;
+  apply) cmd_apply ;;
+  *)
+    echo "usage: $0 {check|diff|apply}" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## What

Adopt the cogworks-canonical suite standards merged in [cogworks#32](https://github.com/gezmodean-wow/cogworks/issues/32). Adds the Standards acknowledgments block to `CLAUDE.md` and seeds the `shared/` file pool (issue/PR templates, `pre-tag-check.sh`, `sync-standards.sh`).

## Why

Refs cogworks#32. Wires Tally into the suite-wide standards mechanism so future runbook revisions flow via the acknowledgment / `Standards updated:` prefix and `shared/` files sync via `bash scripts/sync-standards.sh apply`.

## What was tested

- `bash scripts/sync-standards.sh diff` — all 5 synced files match canonical when normalised for line endings (Windows `core.autocrlf=true` reports CRLF in working tree; git index stores LF, which is what CI/raw fetch sees).
- Each runbook source manually re-fetched and confirmed at top entry `2026-05-05a`; scribe `PLAYER_FACING_CONVENTIONS.md` confirmed at `2026-04-30f`. CLAUDE.md acknowledgments codes match.
- No code changes — purely additive scaffolding + a CLAUDE.md section.

## Self-review checklist

- [x] Issue linked above (Refs cogworks#32 — no Tally-side issue, this is a suite-wide rollout chore)
- [x] Manual exercise described above
- [ ] CI green on this branch (`verify-package` + any other workflow checks) — pending push
- [x] No leftover debug prints / TODOs without a follow-up ticket
- [x] N/A — RELEASES.md (eng-only, no player-visible change)
- [x] N/A — CHANGELOG.md (eng-only, no shipped behavior change)
- [x] N/A — no `.pkgmeta` Cogworks-1.0 bump in this PR

## Out-of-scope follow-ups

- **`sync-standards.sh check` parsing bug** — the awk pulls the entire third pipe field from the CLAUDE.md table row, which on the `shared/` row includes the trailing `` `bash scripts/sync-standards.sh check` `` annotation, so it never compares equal to the bare remote code. Will file as a cogworks issue (canonical script lives in `cogworks/shared/scripts/sync-standards.sh`).
- **Missing `.gitattributes`** — the bootstrap doesn't ship one, so Windows checkouts get CRLF on `*.sh` files (only matters for local execution; CI runners are fine). Will file as a cogworks issue to add `*.sh text eol=lf` to canonical `.gitattributes` shipped via `shared/`.
- Supply-chain fix (pin `verify-package` workflow ref from `@main` to a tag) is a separate follow-up PR per the bootstrap commit message.